### PR TITLE
Added a fn to test keypair validation

### DIFF
--- a/ntge-core/src/ed25519.rs
+++ b/ntge-core/src/ed25519.rs
@@ -13,7 +13,7 @@ pub fn create_keypair() -> Keypair {
     Keypair::generate(&mut csprng)
 }
 
-pub fn from_private_key(private_key: &SecretKey) -> Keypair {
+pub fn construct_from_private_key(private_key: &SecretKey) -> Keypair {
     let sk: SecretKey = (SecretKey::from_bytes(&(private_key.to_bytes())).unwrap());
     let pk: PublicKey = (&sk).into();
 

--- a/ntge-core/src/ed25519.rs
+++ b/ntge-core/src/ed25519.rs
@@ -13,14 +13,21 @@ pub fn create_keypair() -> Keypair {
     Keypair::generate(&mut csprng)
 }
 
-pub fn serialize_private_key(keypair: &Keypair) -> String {
-    let data = keypair.secret.to_bytes().to_base32();
+pub fn from_private_key(private_key: &SecretKey) -> Keypair {
+    let sk: SecretKey = (SecretKey::from_bytes(&(private_key.to_bytes())).unwrap());
+    let pk: PublicKey = (&sk).into();
+
+    Keypair{ public: pk, secret: sk }
+}
+
+pub fn serialize_private_key(private_key: &SecretKey) -> String {
+    let data = private_key.to_bytes().to_base32();
     let encoded = bech32::encode("pri", data).unwrap();
     encoded + "-" + CURVE_NAME_ED25519
 }
 
-pub fn serialize_public_key(keypair: &Keypair) -> String {
-    let data = keypair.public.to_bytes().to_base32();
+pub fn serialize_public_key(public_key: &PublicKey) -> String {
+    let data = public_key.to_bytes().to_base32();
     let encoded = bech32::encode("pub", data).unwrap();
     encoded + "-" + CURVE_NAME_ED25519
 }
@@ -168,3 +175,4 @@ pub fn deserialize_public_key(encoded: &str) -> Result<PublicKey, error::CoreErr
         Ok(public_key)
     }
 }
+

--- a/ntge-core/src/key_utils.rs
+++ b/ntge-core/src/key_utils.rs
@@ -11,12 +11,16 @@ pub const CURVE_NAME_ED25519: &'static str = "Ed25519";
 
 pub fn keypair_validation(private_key: &SecretKey, public_key: &PublicKey) -> bool {
     let keypair: Keypair = from_private_key(private_key);
-    assert_eq!( keypair.public.to_bytes(), (*public_key).to_bytes() );
+    if  keypair.public.to_bytes() != (*public_key).to_bytes() {
+        return false;
+    }
 
     let expanded_private: ExpandedSecretKey = ExpandedSecretKey::from(private_key);
     let message: &[u8] = "Test".as_bytes();
     let signature: Signature = expanded_private.sign(message, public_key);
-    assert!(public_key.verify(message, &signature).is_ok());
 
-    true
+    match public_key.verify(message, &signature) {
+        Ok(()) => true,
+        Err(err) => false
+    }
 }

--- a/ntge-core/src/key_utils.rs
+++ b/ntge-core/src/key_utils.rs
@@ -10,7 +10,7 @@ use super::error;
 pub const CURVE_NAME_ED25519: &'static str = "Ed25519";
 
 pub fn keypair_validation(private_key: &SecretKey, public_key: &PublicKey) -> bool {
-    let keypair: Keypair = from_private_key(private_key);
+    let keypair: Keypair = construct_from_private_key(private_key);
     if  keypair.public.to_bytes() != (*public_key).to_bytes() {
         return false;
     }

--- a/ntge-core/src/key_utils.rs
+++ b/ntge-core/src/key_utils.rs
@@ -1,0 +1,22 @@
+use bech32::{self, FromBase32, ToBase32};
+use ed25519_dalek::Keypair;
+use ed25519_dalek::{SecretKey, PublicKey};
+use ed25519_dalek::{ExpandedSecretKey, Signature};
+use rand::rngs::OsRng;
+pub use crate::ed25519::*;
+
+use super::error;
+
+pub const CURVE_NAME_ED25519: &'static str = "Ed25519";
+
+pub fn keypair_validation(private_key: &SecretKey, public_key: &PublicKey) -> bool {
+    let keypair: Keypair = from_private_key(private_key);
+    assert_eq!( keypair.public.to_bytes(), (*public_key).to_bytes() );
+
+    let expanded_private: ExpandedSecretKey = ExpandedSecretKey::from(private_key);
+    let message: &[u8] = "Test".as_bytes();
+    let signature: Signature = expanded_private.sign(message, public_key);
+    assert!(public_key.verify(message, &signature).is_ok());
+
+    true
+}

--- a/ntge-core/src/lib.rs
+++ b/ntge-core/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod ed25519;
 pub mod error;
+pub mod key_utils;

--- a/ntge-core/tests/ed25519.rs
+++ b/ntge-core/tests/ed25519.rs
@@ -10,7 +10,7 @@ mod tests {
     }
 
     #[test]
-    fn it_create_keypair() {
+    fn it_creates_a_keypair() {
         let keypair = ed25519::create_keypair();
 
         let serialized_private_key = ed25519::serialize_private_key(&(keypair.secret));
@@ -35,7 +35,7 @@ mod tests {
     }
 
     #[test]
-    fn it_deserialize_private_key() {
+    fn it_deserializes_a_private_key() {
         let encoded_private_key =
             "pri1kq9sn9nyutfwsrauz2akl0d0qxzu38dnes6q47x6tnaf57ad7xnsg2fq6l-Ed25519";
         let deserialized_private_key = ed25519::deserialize_private_key(&encoded_private_key);
@@ -43,7 +43,7 @@ mod tests {
     }
 
     #[test]
-    fn it_deserialize_public_key() {
+    fn it_deserializes_a_public_key() {
         let encoded_public_key =
             "pub1w0yqh0eple0cpeqc0es7um553e6pfmyuam6x6cu3vaq602d7v6msnal7n5-Ed25519";
         let deserialized_public_key = ed25519::deserialize_public_key(&encoded_public_key);

--- a/ntge-core/tests/ed25519.rs
+++ b/ntge-core/tests/ed25519.rs
@@ -13,10 +13,10 @@ mod tests {
     fn it_create_keypair() {
         let keypair = ed25519::create_keypair();
 
-        let serialized_private_key = ed25519::serialize_private_key(&keypair);
+        let serialized_private_key = ed25519::serialize_private_key(&(keypair.secret));
         println!("{}", serialized_private_key);
 
-        let serialized_public_key = ed25519::serialize_public_key(&keypair);
+        let serialized_public_key = ed25519::serialize_public_key(&(keypair.public));
         println!("{}", serialized_public_key);
 
         let deserialized_private_key = ed25519::deserialize_private_key(&serialized_private_key);

--- a/ntge-core/tests/key_utils.rs
+++ b/ntge-core/tests/key_utils.rs
@@ -1,0 +1,25 @@
+use ntge_core::{ed25519, key_utils};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        assert_eq!(2 + 2, 4);
+    }
+
+    #[test]
+    fn it_validates_a_valid_keypair() {
+        let keypair = ed25519::create_keypair();
+        assert!(key_utils::keypair_validation(&keypair.secret, &keypair.public));
+    }
+
+    #[test]
+    fn it_validates_an_invalid_keypair() {
+        let keypair1 = ed25519::create_keypair();
+        let keypair2 = ed25519::create_keypair();
+
+        assert!(!(key_utils::keypair_validation(&keypair1.secret, &keypair2.public)));
+    }
+}

--- a/ntge/src/bin/ntge-keygen/main.rs
+++ b/ntge/src/bin/ntge-keygen/main.rs
@@ -54,8 +54,8 @@ fn main() {
         return;
     }
     let keypair = ed25519::create_keypair();
-    let public_key_content = ed25519::serialize_public_key(&keypair);
-    let private_key_content = ed25519::serialize_private_key(&keypair);
+    let public_key_content = ed25519::serialize_public_key(&(keypair.public));
+    let private_key_content = ed25519::serialize_private_key(&(keypair.secret));
     if opts.console {
         println!("Your public key is");
         println!("{}", public_key_content);


### PR DESCRIPTION
- Added `keypair_validation()` in `key_utils.rs`
  - It test if the given private key and public key matches
  - Added two tests, one valid and one invalid

- Added `from_private_key()` in `ed25519.rs`
  - it converts a `PrivateKey` to a `Keypair`

- Modified `serialize_private_key` and `serialize_public_key` in `ed25519.rs`
  - Changed the input from `&Keypair` to `&PublicKey` and `&SecretKey`