### PR TITLE
Publish ntge-core on crates.io

### DIFF
--- a/ntge-core/Cargo.toml
+++ b/ntge-core/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 homepage = "https://dimension.im"
 description = "A cryptography tool that supports file encryption, decryption, signing and verifying."
 repository = "https://github.com/DimensionDev/ntge"
-readme = "README"
+readme = "README.md"
 
 [features]
 cbindgen-enable = []

--- a/ntge-core/Cargo.toml
+++ b/ntge-core/Cargo.toml
@@ -5,6 +5,11 @@ authors = ["Yisi Liu <yisiliu@gmail.com>", "CMK <cirno.mainasuk@gmail.com>", "Tl
 edition = "2018"
 build = "build.rs"
 exclude = ["./include/*"]
+license = "MIT"
+homepage = "https://dimension.im"
+description = "A cryptography tool that supports file encryption, decryption, signing and verifying."
+repository = "https://github.com/DimensionDev/ntge"
+readme = "README"
 
 [features]
 cbindgen-enable = []

--- a/ntge-core/README.md
+++ b/ntge-core/README.md
@@ -1,0 +1,3 @@
+# Not That Good Encryption Core (NTGE-CORE)
+
+This library supports ``X25519`` encryption and decryption and ``ED25519`` signature and verification. It also supports conversion from an `Ed25519` key and `X25519` key. More details will be added here. For an overview, please checkout [NTGE](https://github.com/DimensionDev/ntge).


### PR DESCRIPTION
This PR adds required info in the repo to publish `ntge-core` on crates.io.
To test it, you can run `cargo publish --dry-run`