### PR TITLE
Add extra payload feature

### DIFF
--- a/NtgeCore-iOS/NtgeCore/Classes/SDK/Message/Message+Decryptor.swift
+++ b/NtgeCore-iOS/NtgeCore/Classes/SDK/Message/Message+Decryptor.swift
@@ -58,6 +58,18 @@ extension Message.Decryptor {
         return Data(bytes: buffer.data, count: Int(buffer.len))
     }
     
+    public func decryptExtra(fileKey: X25519.FileKey) -> Data? {
+        let buffer = c_message_decryptor_decrypt_extra(raw, fileKey.intoRaw())
+        guard buffer.len > 0 else {
+            return nil
+        }
+        
+        defer {
+            c_buffer_destroy(buffer)
+        }
+        return Data(bytes: buffer.data, count: Int(buffer.len))
+    }
+    
 }
 
 extension Message.Decryptor {

--- a/NtgeCore-iOS/NtgeCore/Classes/SDK/Message/Message+Encryptor.swift
+++ b/NtgeCore-iOS/NtgeCore/Classes/SDK/Message/Message+Encryptor.swift
@@ -42,12 +42,27 @@ extension Message {
 
 extension Message.Encryptor {
     
-    public func encrypt(plaintext: Data, signatureKey: Ed25519.PrivateKey? = nil) -> Message {
+    public func encrypt(plaintext: Data, extraPlaintext: Data? = nil, signatureKey: Ed25519.PrivateKey? = nil) -> Message {
         var plaintextData = plaintext
         let message = plaintextData.withUnsafeMutableBytes { (pointer: UnsafeMutableRawBufferPointer) -> Message in
             let bufferPointer = pointer.bindMemory(to: UInt8.self)
             let buffer = Buffer(data: bufferPointer.baseAddress, len: UInt(plaintext.count))
-            return Message(raw: c_message_encryptor_encrypt_plaintext(raw, buffer, signatureKey?.intoRaw()))
+            
+            if let extraPlaintext = extraPlaintext {
+                // with extra
+                var extraPlaintextData = extraPlaintext
+                let message = extraPlaintextData.withUnsafeMutableBytes { (extraPointer: UnsafeMutableRawBufferPointer) -> Message in
+                    let extraBufferPointer = extraPointer.bindMemory(to: UInt8.self)
+                    let extraBuffer = Buffer(data: extraBufferPointer.baseAddress, len: UInt(extraPlaintext.count))
+                    return Message(raw: c_message_encryptor_encrypt_plaintext_and_extra(raw, buffer, extraBuffer, signatureKey?.intoRaw()))
+                }
+                
+                return message
+                
+            } else {
+                // no extra
+                return Message(raw: c_message_encryptor_encrypt_plaintext(raw, buffer, signatureKey?.intoRaw()))
+            }
         }   // pointer will dealloc here
         
         return message

--- a/NtgeCore-iOS/NtgeCore/Tests/NtgeCoreTests+Ed25519.swift
+++ b/NtgeCore-iOS/NtgeCore/Tests/NtgeCoreTests+Ed25519.swift
@@ -89,7 +89,9 @@ extension NtgeCoreTests_Ed25519 {
         // x1000
         self.measure {
             for _ in 0..<1000 {
-                let _ = Ed25519.Keypair()
+                autoreleasepool {
+                    let _ = Ed25519.Keypair()
+                }
             }
         }
     }
@@ -98,7 +100,9 @@ extension NtgeCoreTests_Ed25519 {
         // x10000
         self.measure {
             for _ in 0..<10000 {
-                let _ = Ed25519.Keypair()
+                autoreleasepool {
+                    let _ = Ed25519.Keypair()
+                }
             }
         }
     }

--- a/NtgeCore-iOS/NtgeCore/Tests/NtgeCoreTests+Message.swift
+++ b/NtgeCore-iOS/NtgeCore/Tests/NtgeCoreTests+Message.swift
@@ -159,7 +159,9 @@ extension NtgeCoreTests_Message {
         
         // 1MB to 10 Recipient
         self.measure {
-            _ = encryptor.encrypt(plaintext: plaintext)
+            autoreleasepool {
+                _ = encryptor.encrypt(plaintext: plaintext)
+            }
         }
     }
     

--- a/NtgeCore-iOS/NtgeCore/Tests/NtgeCoreTests+Message.swift
+++ b/NtgeCore-iOS/NtgeCore/Tests/NtgeCoreTests+Message.swift
@@ -68,10 +68,44 @@ extension NtgeCoreTests_Message {
         let decryptedString = String(data: payload!, encoding: .utf8)
         XCTAssertEqual(plaintext, decryptedString)
         
+        let extraPayload = decryptor.decryptExtra(fileKey: fileKey!)
+        XCTAssertNil(extraPayload)
+        
         let signatureVerified = Message.Decryptor.verifySignature(for: message, use: Ed25519PublicKey)
         XCTAssertTrue(signatureVerified)
         
         let signatureShouldNotVerified = Message.Decryptor.verifySignature(for: message, use: Ed25519.PrivateKey().publicKey)
+        XCTAssertFalse(signatureShouldNotVerified)
+    }
+    
+    func testEncryptAndDecrypt_withExtra_withoutSignature() throws {
+        let keypair = Ed25519.Keypair()
+        let Ed25519PrivateKey = keypair.privateKey
+        let Ed25519PublicKey = keypair.publicKey
+        let x25519PrivateKey = Ed25519PrivateKey.toX25519()
+        let x25519PublicKey = Ed25519PrivateKey.publicKey.toX25519()
+        let encryptor = Message.Encryptor(publicKeys: [x25519PublicKey])
+        
+        let plaintext = "Hello, World!"
+        let plaintextData = Data(plaintext.utf8)
+        let extraPlaintext = "Hello, Extra!"
+        let extraPlaintextData = Data(extraPlaintext.utf8)
+        let message = encryptor.encrypt(plaintext: plaintextData, extraPlaintext: extraPlaintextData)
+        
+        let decryptor = Message.Decryptor(message: message)
+        let fileKey = decryptor.decryptFileKey(privateKey: x25519PrivateKey)
+        XCTAssertNotNil(fileKey)
+        let payload = decryptor.decryptPayload(fileKey: fileKey!)
+        XCTAssertNotNil(payload)
+        let decryptedString = String(data: payload!, encoding: .utf8)
+        XCTAssertEqual(plaintext, decryptedString)
+
+        let extraPayload = decryptor.decryptExtra(fileKey: fileKey!)
+        XCTAssertNotNil(payload)
+        let decryptedExtraString = String(data: extraPayload!, encoding: .utf8)
+        XCTAssertEqual(extraPlaintext, decryptedExtraString)
+        
+        let signatureShouldNotVerified = Message.Decryptor.verifySignature(for: message, use: Ed25519PublicKey)
         XCTAssertFalse(signatureShouldNotVerified)
     }
     

--- a/NtgeCore-iOS/NtgeCore/Tests/NtgeCoreTests+X25519.swift
+++ b/NtgeCore-iOS/NtgeCore/Tests/NtgeCoreTests+X25519.swift
@@ -36,7 +36,9 @@ extension NtgeCoreTests_X25519 {
         // x10000
         self.measure {
             for _ in 0..<10000 {
-                _ = ed25519.toX25519()
+                autoreleasepool {
+                    _ = ed25519.toX25519()
+                }
             }
         }
     }
@@ -46,7 +48,9 @@ extension NtgeCoreTests_X25519 {
         // x10000
         self.measure {
             for _ in 0..<10000 {
-                _ = ed25519.toX25519()
+                autoreleasepool {
+                    _ = ed25519.toX25519()
+                }
             }
         }
     }

--- a/ntge-core/src/aead.rs
+++ b/ntge-core/src/aead.rs
@@ -3,16 +3,32 @@ use chacha20poly1305::aead::{self, Aead, NewAead};
 use chacha20poly1305::ChaCha20Poly1305;
 
 pub(crate) fn aead_encrypt(key: &[u8; 32], plaintext: &[u8]) -> Vec<u8> {
+    aead_encrypt_with_nonce(key, &[0; 12], plaintext)
+}
+
+pub(crate) fn aead_encrypt_with_nonce(
+    key: &[u8; 32],
+    nonce: &[u8; 12],
+    plaintext: &[u8],
+) -> Vec<u8> {
     let key = GenericArray::clone_from_slice(key);
     let aead = ChaCha20Poly1305::new(key);
-    let nonce = GenericArray::from_slice(&[0; 12]);
+    let nonce = GenericArray::from_slice(nonce);
     aead.encrypt(nonce, plaintext.as_ref())
         .expect("we won't overflow the ChaCha20 block counter")
 }
 
 pub(crate) fn aead_decrypt(key: &[u8; 32], ciphertext: &[u8]) -> Result<Vec<u8>, aead::Error> {
+    aead_decrypt_with_nonce(key, &[0; 12], ciphertext)
+}
+
+pub(crate) fn aead_decrypt_with_nonce(
+    key: &[u8; 32],
+    nonce: &[u8; 12],
+    ciphertext: &[u8],
+) -> Result<Vec<u8>, aead::Error> {
     let key = GenericArray::clone_from_slice(key);
     let aead = ChaCha20Poly1305::new(key);
-    let nonce = GenericArray::from_slice(&[0; 12]);
+    let nonce = GenericArray::from_slice(nonce);
     aead.decrypt(nonce, ciphertext.as_ref())
 }

--- a/ntge-core/src/message/decryptor.rs
+++ b/ntge-core/src/message/decryptor.rs
@@ -173,6 +173,29 @@ pub unsafe extern "C" fn c_message_decryptor_decrypt_payload(
 
 #[no_mangle]
 #[cfg(target_os = "ios")]
+pub unsafe extern "C" fn c_message_decryptor_decrypt_extra(
+    decryptor: *mut Decryptor,
+    file_key: *mut FileKey,
+) -> Buffer {
+    let decryptor = &mut *decryptor;
+    let file_key = &mut *file_key;
+    match decryptor.decrypt_extra(&file_key) {
+        Some(bytes) => {
+            let slice = bytes.into_boxed_slice();
+            let data = slice.as_ptr();
+            let len = slice.len();
+            std::mem::forget(slice);
+            Buffer { data, len }
+        }
+        None => Buffer {
+            data: std::ptr::null_mut(),
+            len: 0,
+        },
+    }
+}
+
+#[no_mangle]
+#[cfg(target_os = "ios")]
 pub unsafe extern "C" fn c_message_decryptor_verify_signature(
     message: *mut Message,
     public_key: *mut Ed25519PublicKey,

--- a/ntge-core/src/message/encryptor.rs
+++ b/ntge-core/src/message/encryptor.rs
@@ -217,3 +217,19 @@ pub unsafe extern "C" fn c_message_encryptor_encrypt_plaintext(
     let message = encryptor.encrypt(&data[..], signature_key);
     Box::into_raw(Box::new(message))
 }
+
+#[no_mangle]
+#[cfg(target_os = "ios")]
+pub unsafe extern "C" fn c_message_encryptor_encrypt_plaintext_and_extra(
+    encryptor: *mut Encryptor,
+    plaintext_buffer: Buffer,
+    extra_plaintext_buffer: Buffer,
+    signature_key: *mut Ed25519PrivateKey,
+) -> *mut message::Message {
+    let encryptor = &mut *encryptor;
+    let data = plaintext_buffer.to_bytes();
+    let extra_data = extra_plaintext_buffer.to_bytes();
+    let signature_key = signature_key.as_ref();
+    let message = encryptor.encrypt_with_extra(&data[..], Some(&extra_data[..]), signature_key);
+    Box::into_raw(Box::new(message))
+}

--- a/ntge-core/src/message/mod.rs
+++ b/ntge-core/src/message/mod.rs
@@ -28,11 +28,18 @@ pub struct MessageMac {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MessageExtra {
+    #[serde(with = "serde_bytes")]
+    pub ciphertext: Vec<u8>, // extra content for external useage
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MessagePayload {
     #[serde(with = "serde_bytes")]
     pub nonce: Vec<u8>, // 16 bytes
     #[serde(with = "serde_bytes")]
     pub ciphertext: Vec<u8>,
+    pub extra: Option<MessageExtra>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -256,6 +263,38 @@ mod tests {
     }
 
     #[test]
+    fn it_encrypts_and_decrypts_a_message_with_extra_to_alice() {
+        let plaintext = b"Hello, World!";
+        // alice
+        let alice_keypair = Ed25519Keypair::new();
+        let alice_secret_key: X25519PrivateKey = (&alice_keypair.get_private_key()).into();
+        let alice_public_key: X25519PublicKey = (&alice_keypair.get_public_key()).into();
+
+        let encryptor = encryptor::Encryptor::new(&vec![alice_public_key]);
+        let extra_plaintext = b"This is extra content";
+        let message = encryptor.encrypt_with_extra(plaintext, Some(extra_plaintext), None);
+
+        // create decryptor
+        let decryptor = decryptor::Decryptor::new(&message);
+        // get file key
+        let file_key = decryptor
+            .decrypt_file_key(&alice_secret_key)
+            .expect("could decrypt file key");
+        // check mac
+        assert_eq!(decryptor.verify_message_mac(&file_key), true);
+        // decrypt message payload
+        let decrypted_plaintext = decryptor
+            .decrypt_payload(&file_key)
+            .expect("could decrypt payload");
+        assert_eq!(decrypted_plaintext, plaintext);
+        // decrypt message extra
+        let decrypted_extra_plaintext = decryptor
+            .decrypt_extra(&file_key)
+            .expect("could decrypt extra");
+        assert_eq!(decrypted_extra_plaintext, extra_plaintext);
+    }
+
+    #[test]
     fn it_encodes_and_decodes_a_message_to_alice() {
         let plaintext = b"Hello, World!";
 
@@ -319,7 +358,7 @@ mod tests {
 
         // create decryptor
         let decryptor = decryptor::Decryptor::new(&message);
-        // get file key
+        // get file keycar
         let file_key = decryptor
             .decrypt_file_key(&alice_secret_key_x25519)
             .expect("could decrypt file key");

--- a/ntge-core/src/message/mod.rs
+++ b/ntge-core/src/message/mod.rs
@@ -358,7 +358,7 @@ mod tests {
 
         // create decryptor
         let decryptor = decryptor::Decryptor::new(&message);
-        // get file keycar
+        // get file key
         let file_key = decryptor
             .decrypt_file_key(&alice_secret_key_x25519)
             .expect("could decrypt file key");


### PR DESCRIPTION
Add `MessageExtra` in `MessagePayload`.

The message extra allows the client encrypt plaintext data with optional extra plaintext data. The AEAD uses not all zero nonce but nonce `1` (a.k.a 11 leading **zero** with one trailing **1**). 

The BSON serialization logic guard the struct could handle by the previous SDK that the old `ntge` just ignore the extra entry. It's should not break the previous message encrypt & decrypt compatibility (Please blame me if somewhere causes the breaking).

