### PR TITLE
Port message timestamp

### DIFF
--- a/NtgeCore-iOS/NtgeCore/Classes/SDK/Message/Message.swift
+++ b/NtgeCore-iOS/NtgeCore/Classes/SDK/Message/Message.swift
@@ -27,6 +27,32 @@ public class Message: RustObject {
 
 extension Message {
     
+    public var timestamp: Date? {
+        var timestampText: UnsafeMutablePointer<Int8>? = nil
+        defer {
+            if timestampText != nil {
+                c_strings_destroy_c_char(&timestampText)
+            }
+        }
+        guard c_message_timestamp(raw, &timestampText) == 0, let text = timestampText else {
+            return nil
+        }
+        
+        let string = String(cString: text)
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions.insert(.withFractionalSeconds)
+        guard let date = formatter.date(from: string) else {
+            assertionFailure()
+            return nil
+        }
+        
+        return date
+    }
+    
+}
+
+extension Message {
+    
     public func serialize() throws -> String? {
         var armor: UnsafeMutablePointer<Int8>? = nil
         

--- a/NtgeCore-iOS/NtgeCore/Tests/NtgeCoreTests+Message.swift
+++ b/NtgeCore-iOS/NtgeCore/Tests/NtgeCoreTests+Message.swift
@@ -116,6 +116,22 @@ extension NtgeCoreTests_Message {
 
 extension NtgeCoreTests_Message {
     
+    func testMessageTimestamp() throws {
+        let encryptor = self.newEncryptor(recipientCount: 1)
+        
+        let lengthInBytes = Measurement(value: 1, unit: UnitInformationStorage.megabytes).converted(to: .bytes).value
+        let plaintext = randomData(ofLength: Int(lengthInBytes))
+        
+        let message = encryptor.encrypt(plaintext: plaintext)
+        
+        let date = message.timestamp
+        XCTAssertNotNil(date)
+    }
+    
+}
+
+extension NtgeCoreTests_Message {
+    
     func testPerformance_encrypt_1MB_10Recipient() throws {
         let encryptor = self.newEncryptor(recipientCount: 10)
 

--- a/ntge-core/src/message/encryptor.rs
+++ b/ntge-core/src/message/encryptor.rs
@@ -81,12 +81,12 @@ impl Encryptor {
             Some(private_key) => {
                 let signature = Encryptor::sign(&private_key.raw, &ciphertext);
                 message::MessageMeta {
-                    timestamp: Some(Utc::now().to_string()),
+                    timestamp: Some(Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true)),
                     signature: Some(Signature::new(signature.to_vec())),
                 }
             }
             None => message::MessageMeta {
-                timestamp: Some(Utc::now().to_string()),
+                timestamp: Some(Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true)),
                 signature: None,
             },
         };

--- a/ntge-core/src/message/mod.rs
+++ b/ntge-core/src/message/mod.rs
@@ -477,7 +477,7 @@ mod tests {
 
         let timestamp = &message.meta.timestamp.as_ref().unwrap().clone();
 
-        assert_eq!(timestamp[timestamp.len() - 3..].to_string(), "UTC");
+        assert_eq!(timestamp[timestamp.len() - 1..].to_string(), "Z");
         println!("{:?}", timestamp);
     }
 }

--- a/ntge-core/src/message/mod.rs
+++ b/ntge-core/src/message/mod.rs
@@ -208,6 +208,25 @@ pub unsafe extern "C" fn c_message_deserialize_from_armor(armor: *const c_char) 
     }
 }
 
+#[no_mangle]
+#[cfg(target_os = "ios")]
+pub unsafe extern "C" fn c_message_timestamp(
+    message: *mut Message,
+    timestamp: *mut *mut c_char,
+) -> i32 {
+    let message = &mut *message;
+    match &message.meta.timestamp {
+        Some(text) => {
+            let result = strings::string_to_c_char(text.clone());
+            *timestamp = result;
+            return 0;
+        }
+        None => {
+            return 1;
+        }
+    };
+}
+
 #[cfg(test)]
 mod tests {
     use crate::{
@@ -443,5 +462,22 @@ mod tests {
             &message,
             &alice_public_key,
         ));
+    }
+
+    #[test]
+    fn it_retrieve_message_timestamp() {
+        let plaintext = b"Hello, World!";
+        // alice
+        let alice_keypair = Ed25519Keypair::new();
+        let alice_private_key = alice_keypair.get_private_key();
+        let alice_public_key = alice_keypair.get_public_key();
+        let alice_public_key_x25519: X25519PublicKey = (&alice_public_key).into();
+        let encryptor = encryptor::Encryptor::new(&[alice_public_key_x25519]);
+        let message = encryptor.encrypt(plaintext, Some(&alice_private_key));
+
+        let timestamp = &message.meta.timestamp.as_ref().unwrap().clone();
+
+        assert_eq!(timestamp[timestamp.len() - 3..].to_string(), "UTC");
+        println!("{:?}", timestamp);
     }
 }


### PR DESCRIPTION
Port message optional timestamp. And the timestamp format is ISO 8601 & RFC3339 compatible. Use milliseconds precision and Z tag mark the UTC time zone.

e.g.
`2018-01-26T18:30:09.453Z`

